### PR TITLE
server: update to latest queue implementation

### DIFF
--- a/queue-server/pom.xml
+++ b/queue-server/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.29</version>
+        <version>0.144.62</version>
     </parent>
     <artifactId>killbill-standalone-queue</artifactId>
     <version>0.1.2-SNAPSHOT</version>

--- a/queue-server/src/main/java/org/killbill/queue/standalone/StandaloneQueueNotification.java
+++ b/queue-server/src/main/java/org/killbill/queue/standalone/StandaloneQueueNotification.java
@@ -87,7 +87,9 @@ public class StandaloneQueueNotification extends StandaloneQueueBase implements 
         logger.info("Stopping test instance {}", QUEUE_NAME);
         if (notificationQueue != null) {
             retryableQueueService.stop();
-            notificationQueue.stopQueue();
+            if (!notificationQueue.stopQueue()) {
+                logger.warn("Timed out while shutting down {} queue: IN_PROCESSING entries might be left behind", notificationQueue.getFullQName());
+            }
             notificationQueueService.deleteNotificationQueue(SVC_NAME, QUEUE_NAME);
         }
         super.stop();


### PR DESCRIPTION
The current queue version is quite old (0.24.6).

This new version contains:

* https://github.com/killbill/killbill-commons/issues/90
* https://github.com/killbill/killbill-commons/pull/97
