### PR TITLE
Fix dependency issues after upding killbill-oss-parent -> 0.144.62

### DIFF
--- a/queue-server/pom.xml
+++ b/queue-server/pom.xml
@@ -86,11 +86,23 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -163,6 +175,12 @@
         <dependency>
             <groupId>org.skife.config</groupId>
             <artifactId>config-magic</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
See https://github.com/killbill/standalone-queue/pull/2 where the parent pom was updated.

Compiling the project lead to a failure in the maven dependency plugin:

```
INFO] Checking dependency versions
[ERROR] Found a problem with the direct dependency org.slf4j:slf4j-api of the current project
  Expected version is 1.7.32
  Resolved version is 1.7.32
  Version 1.5.6 was expected by artifact: org.skife.config:config-magic
  Version 1.7.22 was expected by artifact: io.dropwizard.metrics:metrics-core
  Version 1.7.32 was expected by artifacts: org.kill-bill.commons:killbill-clock, org.kill-bill.commons:killbill-jdbi, org.kill-bill.commons:killbill-queue, org.slf4j:slf4j-simple
  Version 2.0.0-alpha1 was expected by artifact: com.zaxxer:HikariCP
```

I simply excluded the slf4j-api from the various artifcats where version mistmatched was reported.